### PR TITLE
Fix YAML syntax problems

### DIFF
--- a/demo.yaml/gphl/gphl-workflow.yaml
+++ b/demo.yaml/gphl/gphl-workflow.yaml
@@ -175,6 +175,11 @@ configuration:
       #        # Testing ONLY:
       #        co.gphl.wf.run_number: 7
 
+      # To enable the dumping of messages and payloads by the workflow.
+      # The messages/payloads will be written into a numbered subdirectory
+      # of the directory specified here.
+      #co.gphl.wf.msgDir: /mnt/scratch_fs1/pkeller/wf_msgs/wf
+
   #    Workflows, The options in the top elements are updated with the options
   #    in the individual type, and passed as options to teh workflow application
   # The following options are set elsewhere and can *not* be set here

--- a/demo.yaml/gphl/gphl_wf_automation_interface.yml
+++ b/demo.yaml/gphl/gphl_wf_automation_interface.yml
@@ -114,7 +114,7 @@ task:
           # maximum_chi is automatically reduced to match kappa motor limits.
           maximum_chi: 48.0  # (°) Optional. Maximum chi value allowed for strategies.
           # Default 48
-          angular tolerance: 1.0  # (°) Optional.
+          angular_tolerance: 1.0  # (°) Optional.
           # Tolerance to distinguish strategy orientations
 
 # Other parameters are set (ultimately) from ISPyB. These are all optional:

--- a/demo.yaml/gphl/gphl_wf_automation_interface.yml
+++ b/demo.yaml/gphl/gphl_wf_automation_interface.yml
@@ -64,7 +64,7 @@ task:
         # from preliminary XDS calculation
         # When init_spot_dir is set, strategy must be the name of the strategy
         # (specified in strategylib.nml) that was actually used for characterisation.
-        strategy: “Char_6_5_multitrigger”
+        strategy: "Char_6_5_multitrigger"
         # Optional: Arithmetic crystal classes expected for the symmetry.
         # Will be used to select a matching indexing solution,
         # and to determine acquisition strategy.
@@ -83,7 +83,7 @@ task:
       # be left empty so the default is used.
       - resolution: 1.7  # (Å) Optional. Defaults to current value,
         # or to diffraction plan aimed_resolution
-        energies: (12.4,)  # tuple(keV) List of energies to use in experiment.
+        energies: [12.4]  # list(keV) List of energies to use in experiment.
         # two or three for MAD (only).
         # First wavelength will be used for calculating strategies, dose budget, etc.
         # Optional, except for MAD - will default to current beamline energy.


### PR DESCRIPTION
 - Python tuple literals are not part of YAML syntax: they are interpreted as strings
 - Unicode left/right double quotation marks (U+201C/U+201D) are not valid string delimiters: they are interpreted as part of the string itself